### PR TITLE
fix mysql error 'token' data to loong

### DIFF
--- a/api/models/AccessToken.js
+++ b/api/models/AccessToken.js
@@ -24,7 +24,7 @@ module.exports = {
   },
 
   beforeCreate: function(values, next){
-    values.token = UtilsService.uid(256);
+    values.token = UtilsService.uid(255);
     next();
   }
 


### PR DESCRIPTION
I just change api/models/AccessToken.js line 27
`values.token = UtilsService.uid(255);`
